### PR TITLE
Add IE11 build config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,6 +21,14 @@ const options = [
   {
     name,
     umdName,
+    formatName: 'ie11',
+    format: 'cjs',
+    env: 'production',
+    input: pkg.source,
+  },
+  {
+    name,
+    umdName,
     format: 'esm',
     input: pkg.source,
   },

--- a/rollup/createRollupConfig.js
+++ b/rollup/createRollupConfig.js
@@ -34,6 +34,13 @@ export function createRollupConfig(options) {
     .filter(Boolean)
     .join('.');
 
+  let paths;
+  if (options.formatName === 'ie11') {
+    paths = {
+      'react-hook-form': 'react-hook-form/dist/index.ie11',
+    };
+  }
+
   return {
     input: options.input,
     output: {
@@ -47,6 +54,7 @@ export function createRollupConfig(options) {
         'react-hook-form': 'ReactHookForm',
       },
       exports: 'named',
+      paths,
     },
     plugins: [
       external({


### PR DESCRIPTION
👋🏻 

Related to https://github.com/react-hook-form/resolvers/issues/64#issuecomment-716622211

This PR add the IE11 build with the right version of `react-hook-form`. Similar to https://github.com/react-hook-form/resolvers/pull/68

Output:
![Screen Shot 2020-10-26 at 19 24 27](https://user-images.githubusercontent.com/7545547/97212549-df278180-17c0-11eb-8b8b-b8aca80ecd66.png)
